### PR TITLE
remove `-logfile` arg that causes server to fail

### DIFF
--- a/src/helper/xorguserhelper.cpp
+++ b/src/helper/xorguserhelper.cpp
@@ -150,9 +150,6 @@ bool XOrgUserHelper::startServer(const QString &cmd)
     // Append VT from environment
     args << QStringLiteral("vt%1").arg(serverEnv.value(QStringLiteral("XDG_VTNR")));
 
-    // Log to stdout
-    args << QStringLiteral("-logfile") << QStringLiteral("/dev/null");
-
     // Command string
     serverCmd += QLatin1Char(' ') + args.join(QLatin1Char(' '));
 


### PR DESCRIPTION
See https://github.com/sddm/sddm/issues/1414 and https://linux.die.net/man/1/xorg. And the comment on that line was also wrong.

Fixes issue #1414